### PR TITLE
git url for publishing docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "ember-addon"
   ],
-  "repository": "",
+  "repository": "https://github.com/dunkinbase/ember-elements",
   "license": "MIT",
   "author": "",
   "directories": {


### PR DESCRIPTION
Initial release version of ember-elements:- ` "version": "0.1.0"`
Added git url for doc reference:- `"repository": "https://github.com/dunkinbase/ember-elements"`