### PR TITLE
Adds text align option for button-group

### DIFF
--- a/addon/components/button-group/component.ts
+++ b/addon/components/button-group/component.ts
@@ -5,17 +5,25 @@ import Ember from 'ember';
 import { classNames, tagName, attribute, layout, className } from '@ember-decorators/component';
 import { readOnly } from '@ember-decorators/object/computed';
 import * as Classes from "../../-private/common/classes";
+import { Alignment } from "../../-private/common/alignment";
+import { computed } from '@ember-decorators/object';
 @layout(template)
 @tagName('div')
 @classNames(Classes.BUTTON_GROUP)
 export default class ButtonGroup extends Component {
   @attribute('style') style: string = Ember.String.htmlSafe(this.style);
   @className(Classes.VERTICAL)
-  vertical:boolean = false;
+  vertical: boolean = false;
   @className(Classes.MINIMAL)
-  minimal:boolean = false;
+  minimal: boolean = false;
   @className(Classes.LARGE)
-  large:boolean = false;
+  large: boolean = false;
   @className(Classes.FILL)
-  fill:boolean = false;
+  fill: boolean = false;
+  @readOnly('alignText') aligntext: Alignment;
+  @className
+  @computed('aligntext')
+  get aligntextStyle() {
+    return this.aligntext ? Classes.alignmentClass(this.aligntext) : '';
+  }
 };

--- a/addon/components/button/component.ts
+++ b/addon/components/button/component.ts
@@ -14,7 +14,7 @@ import { computed } from '@ember-decorators/object';
 @classNames(Classes.BUTTON)
 export default class Button extends Component {
   @attribute('style') style:string = Ember.String.htmlSafe(this.style);
-  @alias(Classes.BUTTON_TEXT) BUTTON_TEXT:string;
+  BUTTON_TEXT:string=Classes.BUTTON_TEXT;
   @readOnly('iconSize') IconSize:number;
   @className(Classes.ACTIVE)
   active:boolean = false;

--- a/tests/dummy/app/docs/core/button-group/controller.ts
+++ b/tests/dummy/app/docs/core/button-group/controller.ts
@@ -6,7 +6,10 @@ export default class DocsCoreButtonGroup extends Controller {
   large: boolean = false;
   vertical: boolean = false;
   minimal: boolean = false;
-
+  alignText: string = '';
+  leftActive: boolean = false;
+  centerActive: boolean = false;
+  rightActive: boolean = false;
   @action
   onChangeProps(type: string) {
     if (type == 'fill')
@@ -17,7 +20,27 @@ export default class DocsCoreButtonGroup extends Controller {
       this.set('vertical', !this.vertical);
     else if (type == 'minimal')
       this.set('minimal', !this.minimal);
-
+  }
+  @action
+  onTextAlign(type: string) {
+    if (type == 'left') {
+      this.set('alignText', 'left');
+      this.set('leftActive', true);
+      this.set('rightActive', false);
+      this.set('centerActive', false);
+    }
+    else if (type == "center") {
+      this.set('alignText', 'center');
+      this.set('leftActive', false);
+      this.set('rightActive', false);
+      this.set('centerActive', true);
+    }
+    else {
+      this.set('alignText', 'right');
+      this.set('leftActive', false);
+      this.set('rightActive', true);
+      this.set('centerActive', false);
+    }
   }
 }
 

--- a/tests/dummy/app/docs/core/button-group/template.md
+++ b/tests/dummy/app/docs/core/button-group/template.md
@@ -10,7 +10,7 @@
   <div class="docs-example-frame docs-example-frame-row">
     <div class="docs-example">
       {{! BEGIN-SNIPPET docs-example-basic-button-group.hbs }}
-      <ButtonGroup @minimal={{minimal}} @large={{large}} @vertical={{vertical}} @fill={{fill}}>
+      <ButtonGroup @minimal={{minimal}} @large={{large}} @vertical={{vertical}} @fill={{fill}} @alignText={{alignText}}>
         <Button @icon='database' @type='button' @text='Queries'> </Button>
         <Button @icon='function' @type='button' @text='Functions'> </Button>
         <Button @icon='cog' @type='button' @text='Settings'> </Button>
@@ -27,6 +27,13 @@
           class="bp3-control-indicator"></span>Minimal</label>
       <label class="bp3-control bp3-switch"><input type="checkbox" onclick={{action "onChangeProps" 'vertical'}}><span
           class="bp3-control-indicator"></span>Vertical</label>
+      <div> Align text
+        <ButtonGroup @fill=true>
+          <Button @text="Left" @active={{leftActive}} @onClick={{action "onTextAlign" "left"}} />
+          <Button @text="Center" @active={{centerActive}} @onClick={{action "onTextAlign" "center"}} />
+          <Button @text="Right" @active={{rightActive}} @onClick={{action "onTextAlign" "right"}} />
+        </ButtonGroup>
+      </div>
     </div>
   </div>
 </div>
@@ -34,18 +41,35 @@
 {{demo.snippet name='docs-example-basic-button-group.hbs'}}
 {{/docs-demo}}
 
-### List of Arguments
+### Props
 
 
 <div class="docs-modifiers-table bp3-running-text">
   <table class="bp3-html-table">
     <thead>
       <tr>
-        <th>Arguments</th>
+        <th>Props</th>
         <th>Description</th>
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td class="docs-prop-name"><code>alignText</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Text alignment within button. By default, icons and text will be centered
+                  within the button. Passing <code>"left"</code> or <code>"right"</code> will align the button
+                  text to that side and push <code>icon</code> and <code>rightIcon</code> to either edge. Passing
+                  <code>"center"</code> will center the text and icons together.</p>
+              </div>
+            </div>
+          </div>
+          <div class="docs-prop-tags"></div>
+        </td>
+      </tr>
       <tr>
         <td class="docs-prop-name"><code>class</code></td>
         <td class="docs-prop-details"><code

--- a/tests/integration/components/button-group/component-test.ts
+++ b/tests/integration/components/button-group/component-test.ts
@@ -88,4 +88,14 @@ module('Integration | Component | button-group', function(hooks) {
     let element = this.element;
     assert.equal(element.querySelectorAll('.bp3-fill').length, 0);
   });
+  test('text align left', async function (assert) {
+    await render(hbs`<ButtonGroup @alignText="left" />`);
+    let element = this.element;
+    assert.equal(element.querySelectorAll('.bp3-align-left').length, 1);
+  });
+  test('text align right', async function (assert) {
+    await render(hbs`<ButtonGroup @alignText="right" />`);
+    let element = this.element;
+    assert.equal(element.querySelectorAll('.bp3-align-right').length, 1);
+  });
 });


### PR DESCRIPTION
`alignText`  option for text alignment. There are 3 option are 
1. "left"
2. "right"
3. "center"

Text alignment within button. By default, icons and text will be centered within the button. Passing "left" or "right" will align the button text to that side and push icon and rightIcon to either edge. Passing "center" will center the text and icons together.