### PR TITLE
BugFix_children props for selected components   

### DIFF
--- a/addon/components/date-picker/component.ts
+++ b/addon/components/date-picker/component.ts
@@ -67,6 +67,7 @@ export default class DatePicker extends Component {
   popperClass: string = 'popper';
   popOverArrow!: boolean;
   minimal: boolean = false;
+  onClick!: (open: boolean) => void;
 
   init() {
     super.init();
@@ -126,6 +127,9 @@ export default class DatePicker extends Component {
 
   @action
   async togglePopover() {
+    if (this.get('onClick')) {
+      this.get('onClick')(this.open);
+    }
     await this.toggleProperty('open');
   }
 

--- a/addon/components/date-picker/component.ts
+++ b/addon/components/date-picker/component.ts
@@ -5,7 +5,7 @@ import Ember from 'ember';
 import { action, computed } from '@ember-decorators/object';
 import { get, set } from '@ember/object';
 import { classNames, tagName, attribute, layout, className } from '@ember-decorators/component';
-import { readOnly } from '@ember-decorators/object/computed';
+import { readOnly, alias } from '@ember-decorators/object/computed';
 import * as Classes from '../../-private/common/classes';
 @layout(template)
 @tagName('span')
@@ -16,6 +16,29 @@ export default class DatePicker extends Component {
   @readOnly('open') Open?: boolean;
 
   @readOnly('format') Format!: string;
+
+  @alias('InputGroupProps.class') IGCLASS?: string;
+
+  @alias('InputGroupProps.style') IGSTYLE?: string;
+
+  @alias('InputGroupProps.disabled') IGDISABLED?: boolean;
+
+  @alias('InputGroupProps.intent') IGINTENT?: string;
+
+  @alias('InputGroupProps.large') IGLARGE?: boolean;
+
+  @alias('InputGroupProps.leftIcon') IGLEFTICON?: string;
+
+  @alias('InputGroupProps.rightIcon') IGRIGHTICON?: string;
+
+  @alias('InputGroupProps.iconSize') IGICONSIZE?: number;
+
+  @alias('InputGroupProps.round') IGROUND?: boolean;
+
+  @alias('InputGroupProps.small') IGSMALL?: boolean;
+
+  @alias('InputGroupProps.placeholder') IGPLACEHOLDER?: string;
+
 
   @className(Classes.POPOVER_OPEN)
   open: boolean = false;

--- a/addon/components/date-picker/template.hbs
+++ b/addon/components/date-picker/template.hbs
@@ -8,7 +8,7 @@
   @large={{IGLARGE}}
   @leftIcon={{IGLEFTICON}}
   @rightIcon={{IGRIGHTICON}}
-  @iconSize={{iconSize}}
+  @iconSize={{IGICONSIZE}}
   @round={{IGROUND}}
   @small={{IGSMALL}}
   @placeholder={{IGPLACEHOLDER}}

--- a/addon/components/date-picker/template.hbs
+++ b/addon/components/date-picker/template.hbs
@@ -1,12 +1,19 @@
 <InputGroup
   @type="text"
   @onClick={{action "togglePopover"}}
-  @leftIcon={{leftIcon}}
+  @class={{IGCLASS}}
+  @style={{IGSTYLE}}
+  @disabled={{IGDISABLED}}
+  @intent={{IGINTENT}}
+  @large={{IGLARGE}}
+  @leftIcon={{IGLEFTICON}}
+  @rightIcon={{IGRIGHTICON}}
   @iconSize={{iconSize}}
-  @rightIcon={{rightIcon}}
-  @intent={{intent}}
-  @placeholder={{dateFormat}}
+  @round={{IGROUND}}
+  @small={{IGSMALL}}
+  @placeholder={{IGPLACEHOLDER}}
   @value={{moment-format date dateFormat}}
+  @onkeyDown={{onkeyDown}}
  />
 
 {{#if open}}

--- a/addon/components/date-range-picker/component.ts
+++ b/addon/components/date-range-picker/component.ts
@@ -5,7 +5,7 @@ import Ember from 'ember';
 import { action, computed } from '@ember-decorators/object';
 import { get, set } from '@ember/object';
 import { classNames, tagName, attribute, layout, className } from '@ember-decorators/component';
-import { readOnly } from '@ember-decorators/object/computed';
+import { readOnly, alias } from '@ember-decorators/object/computed';
 import moment from 'moment';
 import * as Classes from '../../-private/common/classes';
 @tagName('span')
@@ -20,11 +20,33 @@ export default class DateRangePicker extends Component {
   open: boolean = false;
 
   @attribute('style') style: any = Ember.String.htmlSafe(this.style);
- 
+
   @computed('Format')
   get dateFormat() {
     return this.Format ? this.Format : this.defaultFormat;
   }
+
+  @alias('InputGroupProps.class') IGCLASS?: string;
+
+  @alias('InputGroupProps.style') IGSTYLE?: string;
+
+  @alias('InputGroupProps.disabled') IGDISABLED?: boolean;
+
+  @alias('InputGroupProps.intent') IGINTENT?: string;
+
+  @alias('InputGroupProps.large') IGLARGE?: boolean;
+
+  @alias('InputGroupProps.leftIcon') IGLEFTICON?: string;
+
+  @alias('InputGroupProps.rightIcon') IGRIGHTICON?: string;
+
+  @alias('InputGroupProps.iconSize') IGICONSIZE?: number;
+
+  @alias('InputGroupProps.round') IGROUND?: boolean;
+
+  @alias('InputGroupProps.small') IGSMALL?: boolean;
+
+  @alias('InputGroupProps.placeholder') IGPLACEHOLDER?: string;
 
   _popperTarget: any;
   TRANSITION_CONTAINER: string = Classes.TRANSITION_CONTAINER;
@@ -53,6 +75,7 @@ export default class DateRangePicker extends Component {
   popperClass: string = 'popper';
   popOverArrow!: boolean;
   minimal: boolean = false;
+  onClick!: (open: boolean) => void;
 
   init() {
     super.init();
@@ -62,7 +85,7 @@ export default class DateRangePicker extends Component {
       set(this, 'range2', new Date(this.range.start.getFullYear(), this.range.start.getMonth() + 1, this.range.start.getDate()));
     }
   }
-  
+
   didInsertElement() {
     set(this, '_popperTarget', this.element);
     this.set('currentWindow', this.$(window));
@@ -94,7 +117,7 @@ export default class DateRangePicker extends Component {
       }
     }
   }
-  
+
   @action
   changeCenter(unit: any, calendar: any, e: any) {
     let newCenter;
@@ -114,6 +137,9 @@ export default class DateRangePicker extends Component {
 
   @action
   togglePopover() {
+    if (this.get('onClick')) {
+      this.get('onClick')(this.open);
+    }
     this.toggleProperty('open');
   }
 
@@ -167,14 +193,14 @@ export default class DateRangePicker extends Component {
 
   _closeOnClickOut(e: any) {
     const clickIsInside = document.querySelector('.bp3-transition-container');
-    const clickIsInsideFound =clickIsInside?clickIsInside.contains(e.target):false
+    const clickIsInsideFound = clickIsInside ? clickIsInside.contains(e.target) : false
     if (!clickIsInsideFound) { this._close(); }
   }
 
   _closeOnEsc(e: any) {
     if (e.keyCode === this.ESC) { this._close(); }
   }
-  
+
   _close() {
     if (this.isDestroyed || this.isDestroying)
       return;

--- a/addon/components/date-range-picker/template.hbs
+++ b/addon/components/date-range-picker/template.hbs
@@ -1,11 +1,18 @@
 <InputGroup
   @type="text"
   @onClick={{action "togglePopover"}}
-  @leftIcon={{leftIcon}}
-  @iconSize={{iconSize}}
-  @rightIcon={{rightIcon}}
-  @intent={{intent}}
-  @placeholder={{dateFormat}}
+  @class={{IGCLASS}}
+  @style={{IGSTYLE}}
+  @disabled={{IGDISABLED}}
+  @intent={{IGINTENT}}
+  @large={{IGLARGE}}
+  @leftIcon={{IGLEFTICON}}
+  @rightIcon={{IGRIGHTICON}}
+  @iconSize={{IGICONSIZE}}
+  @round={{IGROUND}}
+  @small={{IGSMALL}}
+  @placeholder={{IGPLACEHOLDER}}
+  @onkeyDown={{onkeyDown}}
   @value={{date}}
  />
 

--- a/addon/components/select/component.ts
+++ b/addon/components/select/component.ts
@@ -15,10 +15,56 @@ export default class Select extends Component {
 
   @reads('open') Open!: boolean;
 
-  @alias('buttonProps.minimal') buttonMinimal?: boolean;
+  @alias('ButtonProps.class') BCLASS?: string;
+
+  @alias('ButtonProps.style') BSTYLE?: string;
+
+  @alias('ButtonProps.active') BACTIVE?: boolean;
+
+  @alias('ButtonProps.disabled') BDISABLED?: boolean;
+
+  @alias('ButtonProps.intent') BINTENT?: string;
+
+  @alias('ButtonProps.fill') BFILL?: boolean;
+
+  @alias('ButtonProps.icon') BICON?: string;
+
+  @alias('ButtonProps.iconSize') BICONSIZE?: number;
+
+  @alias('ButtonProps.large') BLARGE?: boolean;
+
+  @alias('ButtonProps.minimal') BMINIMAL?: boolean;
+
+  @alias('ButtonProps.rightIcon') BRIGHTICON?: string;
+
+  @alias('ButtonProps.small') BSMALL?: boolean;
 
   @className(Classes.POPOVER_OPEN)
   open: boolean = false;
+
+  @alias('InputGroupProps.class') IGCLASS?: string;
+
+  @alias('InputGroupProps.style') IGSTYLE?: string;
+
+  @alias('InputGroupProps.disabled') IGDISABLED?: boolean;
+
+  @alias('InputGroupProps.intent') IGINTENT?: string;
+
+  @alias('InputGroupProps.large') IGLARGE?: boolean;
+
+  @alias('InputGroupProps.leftIcon') IGLEFTICON?: string;
+
+  @alias('InputGroupProps.rightIcon') IGRIGHTICON?: string;
+
+  @alias('InputGroupProps.iconSize') IGICONSIZE?: number;
+
+  @alias('InputGroupProps.round') IGROUND?: boolean;
+
+  @alias('InputGroupProps.small') IGSMALL?: boolean;
+
+  @alias('InputGroupProps.placeholder') IGPLACEHOLDER?: string;
+
+  @alias('InputGroupProps.autofocus') IGAUTOFOCUS?: string;
 
   currentWindow: any;
   _popperTarget: any;
@@ -49,6 +95,7 @@ export default class Select extends Component {
   popOverArrow!: boolean;
   minimal: boolean = false;
   defaultSelected: number = -1;
+  onClick!: (open: boolean) => void;
 
   init() {
     super.init();
@@ -133,6 +180,9 @@ export default class Select extends Component {
 
   @action
   async togglePopover() {
+    if (this.get('onClick')) {
+      this.get('onClick')(this.open);
+    }
     await this.toggleProperty('open');
     let data: any[] = JSON.parse(JSON.stringify(this.get('data') || []));
     this.findDefaultSelect(data);

--- a/addon/components/select/template.hbs
+++ b/addon/components/select/template.hbs
@@ -4,24 +4,40 @@
   </a>
 {{else if (eq type "button")}}
   <Button
+    @class={{BCLASS}}
+    @style={{BSTYLE}}
+    @active={{BACTIVE}}
+    @disabled={{BDISABLED}}
+    @intent={{BINTENT}}
+    @fill={{BFILL}}
+    @icon={{BICON}}
+    @iconSize={{BICONSIZE}}
+    @large={{BLARGE}}
+    @minimal={{BMINIMAL}}
+    @rightIcon={{BRIGHTICON}}
+    @small={{BSMALL}}
     @text={{selected}}
-    @minimal={{buttonMinimal}}
-    @active={{active}}
     @onClick={{action "togglePopover"}}
-    @icon={{icon}}
-    @rightIcon={{rightIcon}}
    />
 
 {{else}}
   <InputGroup
     @onClick={{action "togglePopover"}}
-    @autofocus={{isDefaultOpen}}
-    @placeholder={{placeholder}}
+    @autofocus={{IGAUTOFOCUS}}
     @value={{selected}}
-    @leftIcon={{leftIcon}}
-    @rightIcon={{rightIcon}}
     @onkeyDown={{action "handleKeydown"}}
     @onkeyUp={{action "onSearchElement"}}
+    @class={{IGCLASS}}
+    @style={{IGSTYLE}}
+    @disabled={{IGDISABLED}}
+    @intent={{IGINTENT}}
+    @large={{IGLARGE}}
+    @leftIcon={{IGLEFTICON}}
+    @rightIcon={{IGRIGHTICON}}
+    @iconSize={{IGICONSIZE}}
+    @round={{IGROUND}}
+    @small={{IGSMALL}}
+    @placeholder={{IGPLACEHOLDER}}
    />
 
 {{/if}}

--- a/tests/dummy/app/docs/core/input-group/controller.ts
+++ b/tests/dummy/app/docs/core/input-group/controller.ts
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember-decorators/object';
+import Ember from 'ember';
 
 export default class DocsCoreInputGroup extends Controller {
   // normal class body definition here
@@ -14,8 +15,10 @@ export default class DocsCoreInputGroup extends Controller {
   data: Array<string> = ['can edit', 'can view'];
   selected: string = 'can edit';
   tagValueChange: number = Math.floor(10000 / Math.max(1, Math.pow(this.tagValue.length, 2)));
-  buttonprops: object = {
+  ButtonProps: any = {
     minimal: true,
+    rightIcon: 'caret-down',
+    disabled: this.isDisabled
   }
   // BEGIN-SNIPPET docs-example-basic-input-group.ts
   @action
@@ -51,6 +54,7 @@ export default class DocsCoreInputGroup extends Controller {
   @action
   disableFun() {
     this.toggleProperty('isDisabled');
+    Ember.set(this.ButtonProps, 'disabled', this.isDisabled);
   }
   @action
   smallFun() {

--- a/tests/dummy/app/docs/core/input-group/template.md
+++ b/tests/dummy/app/docs/core/input-group/template.md
@@ -15,7 +15,7 @@
         @large={{isLarge}} 
         @small={{isSmall}}
         @intent={{intent}} 
-        @rightIcon='lock' >
+      >
       </InputGroup>
       <InputGroup 
         @type={{type}} 
@@ -46,12 +46,10 @@
         @small={{isSmall}} 
         @intent={{intent}}  
         @onkeyDown={{action 'onkeyDown'}}>
-        <Select @data={{data}} @type='button' @disabled={{isDisabled}}   
+        <Select @data={{data}} @type='button'    
          @selected={{selected}} 
-         @rightIcon="caret-down"  
          @minimal={{false}}
-         @minimalButton=true
-         @buttonProps={{buttonprops}}
+         @ButtonProps={{ButtonProps}}
          @onSelect={{action 'optionSelected' }}>
         </Select>
         </InputGroup>

--- a/tests/dummy/app/docs/date/date-picker/controller.js
+++ b/tests/dummy/app/docs/date/date-picker/controller.js
@@ -5,9 +5,13 @@ export default class DocsDateDatePicker extends Controller {
   // normal class body definition here
   // BEGIN-SNIPPET docs-example-basic-date-picker.js
   minimal: boolean = false;
-  placement:string='auto';
+  placement: string = 'auto';
   format: string = 'DD-MM-YYYY'; //this is default date format 
   date: any = '03/04/2018';
+  InputGroupProps: object = {
+    leftIcon: 'calendar',
+    placeholder: this.format,
+  }
   @action
   selectDate(date: any) {
     console.log('date is ', moment(date).format(this.format));// date convertion
@@ -21,6 +25,10 @@ export default class DocsDateDatePicker extends Controller {
     this.set('placement', e.target.value);
   }
   // END-SNIPPET
+  @action
+  openInputGroupProps() {
+    this.set('isOpenDrawer', true);
+  }
 }
 
 // DO NOT DELETE: this is how TypeScript knows how to look up your controllers.

--- a/tests/dummy/app/docs/date/date-picker/template.md
+++ b/tests/dummy/app/docs/date/date-picker/template.md
@@ -11,8 +11,10 @@
     <div class="docs-example-frame docs-example-frame-row">
         <div class="docs-example">
                    {{! BEGIN-SNIPPET docs-example-basic-date-picker.hbs }}
-                    <DatePicker @onSelect={{action 'selectDate' }} @leftIcon="calendar"
-                     @date={{date}} @minimal={{minimal}} @placement={{placement}}>
+                    <DatePicker @onSelect={{action 'selectDate' }}
+                     @date={{date}} @minimal={{minimal}} 
+                     @InputGroupProps={{InputGroupProps}}
+                     @placement={{placement}}>
                     </DatePicker>
                    {{! END-SNIPPET }}
         </div>
@@ -179,7 +181,181 @@
                     <div class="docs-prop-tags"></div>
                 </td>
             </tr>
+             <tr>
+                <td class="docs-prop-name"><code>InputGroupProps</code></td>
+                <td class="docs-prop-details"><code class="docs-prop-type"><strong>Partial&lt;<a {{action 'openInputGroupProps'}}>InputGroupProps</a>&gt; &amp; object</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p> InputGroupProps for <code>InputGroup</code> component. 
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="docs-prop-tags"></div>
+                </td>
+            </tr>
+       <tr>
+        <td class="docs-prop-name"><code>onkeyDown</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>(data:string, event: MouseEvent&lt;HTMLElement&gt;) =&gt; void</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p> When a user is pressing/holding down a key on input.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
         </tbody>
     </table>
     <br>
 </div>
+<DbDrawer @isOpen={{isOpenDrawer}} 
+ @autoFocus=true @enforceFocus=true
+@hasBackdrop=true @usePortal=true 
+@canOutsideClickClose=true
+@canEscapeKeyClose=true >
+
+{{#db-drawer/body}}
+   <div class="docs-modifiers-table bp3-running-text">
+  <table class="bp3-html-table">
+    <thead>
+      <tr>
+        <th>Props</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="docs-prop-name"><code>class</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>A space-delimited list of class names to pass along to a child element.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>style</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Inline html style to parent element.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>disabled</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Whether the input is non-interactive.
+                   Note that <code>rightElement</code> must be disabled separately; this prop will not affect it.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>intent</code></td>
+        <td class="docs-prop-details">
+          <code class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Visual intent color to apply to element. Options are
+                  <code>primary,success,warning,danger,none.</code></p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr><td class="docs-prop-name"><code>large</code></td><td class="docs-prop-details"><code class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code><div class="docs-prop-description"><div class="docs-section"><div class="bp3-running-text"><p>Whether this input should use large styles.</p>
+</div></div></div><div class="docs-prop-tags"></div></td></tr>
+      <tr>
+        <td class="docs-prop-name"><code>leftIcon</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>IconName </strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Name of a Blueprint UI icon to left side of input.</p>
+              </div>
+            </div>
+          </div>
+          <div class="docs-prop-tags"><span class="bp3-tag bp3-minimal"><span
+                class="bp3-text-overflow-ellipsis bp3-fill">
+                Default icon position is right</span></span></div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>iconSize</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>number</strong><em class="docs-prop-default bp3-text-muted">16</em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Assign Icon size.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>round</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Whether this input should use round styles.</p>
+              </div>
+            </div>
+          </div>
+          <div class="docs-prop-tags"></div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>rightIcon</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>IconName</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Name of a Blueprint UI icon to render after the text.</p>
+              </div>
+            </div>
+          </div>
+          <div class="docs-prop-tags"></div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>small</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Whether this input should use small styles.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+ {{/db-drawer/body}}
+</DbDrawer>

--- a/tests/dummy/app/docs/date/date-range-picker/controller.js
+++ b/tests/dummy/app/docs/date/date-range-picker/controller.js
@@ -1,16 +1,20 @@
 import Controller from '@ember/controller';
 import { action } from '@ember-decorators/object';
 import moment from 'moment';
-export default class DocsDateDateRangePicker extends Controller{
+export default class DocsDateDateRangePicker extends Controller {
   // normal class body definition here
   // BEGIN-SNIPPET docs-example-basic-date-range-picker.ts
   minimal: boolean = false;
-  placement:string='auto';
+  placement: string = 'auto';
   range: object = {
     start: new Date('3/1/2018'),
     end: new Date('3/20/2018')
   };
   format: string = 'DD-MM-YYYY'; //this is default date format 
+  InputGroupProps: object = {
+    leftIcon: 'timeline-events',
+    placeholder: this.format
+  };
   @action
   selectDate(date: object) {
     console.log('start date is ', moment(date.start).format(this.format));// date convertion
@@ -25,6 +29,10 @@ export default class DocsDateDateRangePicker extends Controller{
     this.set('placement', e.target.value);
   }
   // END-SNIPPET
+  @action
+  openInputGroupProps() {
+    this.set('isOpenDrawer', true);
+  }
 }
 
 // DO NOT DELETE: this is how TypeScript knows how to look up your controllers.

--- a/tests/dummy/app/docs/date/date-range-picker/template.md
+++ b/tests/dummy/app/docs/date/date-range-picker/template.md
@@ -11,7 +11,8 @@
             {{! BEGIN-SNIPPET docs-example-basic-date-range-picker.hbs }}
             <DateRangePicker @format={{format}} @range={{this.range}}
              @minimal={{minimal}} @placement={{placement}}
-             @onSelect={{action 'selectDate' }} @leftIcon="timeline-events">
+             @onSelect={{action 'selectDate' }}
+             @InputGroupProps={{InputGroupProps}} >
             </DateRangePicker>
             {{! END-SNIPPET }}
         </div>
@@ -193,7 +194,194 @@
                     <div class="docs-prop-tags"></div>
                 </td>
             </tr>
+             <tr>
+                <td class="docs-prop-name"><code>InputGroupProps</code></td>
+                <td class="docs-prop-details"><code class="docs-prop-type"><strong>Partial&lt;<a {{action 'openInputGroupProps'}}>InputGroupProps</a>&gt; &amp; object</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p> InputGroupProps for <code>InputGroup</code> component. 
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="docs-prop-tags"></div>
+                </td>
+            </tr>
+       <tr>
+        <td class="docs-prop-name"><code>onkeyDown</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>(data:string, event: MouseEvent&lt;HTMLElement&gt;) =&gt; void</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p> When a user is pressing/holding down a key on input.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+       <tr>
+        <td class="docs-prop-name"><code>onClick</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>(open:boolean) =&gt; void</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Input click event handler.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
         </tbody>
     </table>
     <br>
 </div>
+<DbDrawer @isOpen={{isOpenDrawer}} 
+ @autoFocus=true @enforceFocus=true
+@hasBackdrop=true @usePortal=true 
+@canOutsideClickClose=true
+@canEscapeKeyClose=true >
+
+{{#db-drawer/body}}
+   <div class="docs-modifiers-table bp3-running-text">
+  <table class="bp3-html-table">
+    <thead>
+      <tr>
+        <th>Props</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="docs-prop-name"><code>class</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>A space-delimited list of class names to pass along to a child element.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>style</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Inline html style to parent element.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>disabled</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Whether the input is non-interactive.
+                   Note that <code>rightElement</code> must be disabled separately; this prop will not affect it.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>intent</code></td>
+        <td class="docs-prop-details">
+          <code class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Visual intent color to apply to element. Options are
+                  <code>primary,success,warning,danger,none.</code></p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr><td class="docs-prop-name"><code>large</code></td><td class="docs-prop-details"><code class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code><div class="docs-prop-description"><div class="docs-section"><div class="bp3-running-text"><p>Whether this input should use large styles.</p>
+</div></div></div><div class="docs-prop-tags"></div></td></tr>
+      <tr>
+        <td class="docs-prop-name"><code>leftIcon</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>IconName </strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Name of a Blueprint UI icon to left side of input.</p>
+              </div>
+            </div>
+          </div>
+          <div class="docs-prop-tags"><span class="bp3-tag bp3-minimal"><span
+                class="bp3-text-overflow-ellipsis bp3-fill">
+                Default icon position is right</span></span></div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>iconSize</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>number</strong><em class="docs-prop-default bp3-text-muted">16</em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Assign Icon size.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>round</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Whether this input should use round styles.</p>
+              </div>
+            </div>
+          </div>
+          <div class="docs-prop-tags"></div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>rightIcon</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>IconName</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Name of a Blueprint UI icon to render after the text.</p>
+              </div>
+            </div>
+          </div>
+          <div class="docs-prop-tags"></div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>small</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Whether this input should use small styles.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+ {{/db-drawer/body}}
+</DbDrawer>

--- a/tests/dummy/app/docs/select/select/controller.ts
+++ b/tests/dummy/app/docs/select/select/controller.ts
@@ -4,14 +4,26 @@ import { action } from '@ember-decorators/object';
 export default class DocsSelectSelect extends Controller {
   // normal class body definition here
   // normal class body definition here
+  isOpenButtonDrawer: boolean = false;
   // BEGIN-SNIPPET docs-example-basic-select-box.ts
   selected: string = 'April';
+  isOpenDrawer: boolean = false;
   minimal: boolean = false;
   placement: string = 'auto';
   data: Array<string> = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
   selected2: string = 'February';
   data2: Array<string> = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-
+  InputGroupProps: object = {
+    rightIcon: 'caret-down',
+    placeholder: "select..",
+  };
+  ButtonProps: object = {
+    icon: 'select',
+    placeholder: 'select item',
+    rightIcon: 'caret-down',
+    active: 'true',
+    select: 'icon'
+  }
   @action
   optionSelected(selectedValue: string, index: number) {
     console.log(selectedValue, index);
@@ -25,6 +37,14 @@ export default class DocsSelectSelect extends Controller {
     this.set('placement', e.target.value);
   }
   // END-SNIPPET
+  @action
+  openInputGroupProps() {
+    this.set('isOpenDrawer', true);
+  }
+  @action
+  openButtonProps() {
+    this.set('isOpenButtonDrawer', true);
+  }
 }
 
 // DO NOT DELETE: this is how TypeScript knows how to look up your controllers.

--- a/tests/dummy/app/docs/select/select/template.md
+++ b/tests/dummy/app/docs/select/select/template.md
@@ -11,14 +11,16 @@
         <div class="docs-example">
             {{! BEGIN-SNIPPET docs-example-basic-select-box.hbs }}
              <Select @data={{data}} @selected={{selected}} 
-               @rightIcon="caret-down" @placement={{placement}}
-               @minimal={{minimal}} @placeholder='select' 
-               @onSelect={{action 'optionSelected'}}>
+               @placement={{placement}}
+               @minimal={{minimal}}  
+               @onSelect={{action 'optionSelected'}} 
+               @InputGroupProps={{InputGroupProps}}>
             </Select>
             <Select @data={{data2}} @type='button' 
-               @selected={{selected2}} @placeholder='Select item'
-               @rightIcon="caret-down" @icon='select' 
-               @active=true @minimal={{minimal}}
+               @selected={{selected2}} 
+               @rightIcon="caret-down"
+               @ButtonProps={{ButtonProps}} 
+               @minimal={{minimal}}
                @onSelect={{action 'optionSelected' }}>
             </Select>
             {{! END-SNIPPET }}
@@ -213,6 +215,47 @@
                     <div class="docs-prop-tags"></div>
                 </td>
             </tr>
+             <tr>
+                <td class="docs-prop-name"><code>InputGroupProps</code></td>
+                <td class="docs-prop-details"><code class="docs-prop-type"><strong>Partial&lt;<a {{action 'openInputGroupProps'}}>InputGroupProps</a>&gt; &amp; object</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p> InputGroupProps for <code>InputGroup</code> component. 
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="docs-prop-tags"></div>
+                </td>
+            </tr>
+             <tr>
+                <td class="docs-prop-name"><code>ButtonProps</code></td>
+                <td class="docs-prop-details"><code class="docs-prop-type"><strong>Partial&lt;<a {{action 'openButtonProps'}}>ButtonProps</a>&gt; &amp; object</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p> ButtonProps for <code>Button</code> component. 
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="docs-prop-tags"></div>
+                </td>
+            </tr>
+             <tr>
+        <td class="docs-prop-name"><code>onClick</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>(open:boolean) =&gt; void</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Input or button click event handler.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
         </tbody>
     </table>
     <br>
@@ -226,3 +269,385 @@
     </div>
 
 </div>
+<DbDrawer @isOpen={{isOpenDrawer}} 
+ @autoFocus=true @enforceFocus=true
+@hasBackdrop=true @usePortal=true 
+@canOutsideClickClose=true
+@canEscapeKeyClose=true >
+
+{{#db-drawer/body}}
+   <div class="docs-modifiers-table bp3-running-text">
+  <table class="bp3-html-table">
+    <thead>
+      <tr>
+        <th>Props</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="docs-prop-name"><code>class</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>A space-delimited list of class names to pass along to a child element.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>style</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Inline html style to parent element.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>disabled</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Whether the input is non-interactive.
+                   Note that <code>rightElement</code> must be disabled separately; this prop will not affect it.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>intent</code></td>
+        <td class="docs-prop-details">
+          <code class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Visual intent color to apply to element. Options are
+                  <code>primary,success,warning,danger,none.</code></p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr><td class="docs-prop-name"><code>large</code></td><td class="docs-prop-details"><code class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code><div class="docs-prop-description"><div class="docs-section"><div class="bp3-running-text"><p>Whether this input should use large styles.</p>
+</div></div></div><div class="docs-prop-tags"></div></td></tr>
+      <tr>
+        <td class="docs-prop-name"><code>leftIcon</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>IconName </strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Name of a Blueprint UI icon to left side of input.</p>
+              </div>
+            </div>
+          </div>
+          <div class="docs-prop-tags"><span class="bp3-tag bp3-minimal"><span
+                class="bp3-text-overflow-ellipsis bp3-fill">
+                Default icon position is right</span></span></div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>iconSize</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>number</strong><em class="docs-prop-default bp3-text-muted">16</em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Assign Icon size.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>round</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Whether this input should use round styles.</p>
+              </div>
+            </div>
+          </div>
+          <div class="docs-prop-tags"></div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>rightIcon</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>IconName</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Name of a Blueprint UI icon to render after the text.</p>
+              </div>
+            </div>
+          </div>
+          <div class="docs-prop-tags"></div>
+        </td>
+      </tr>
+      <tr>
+        <td class="docs-prop-name"><code>small</code></td>
+        <td class="docs-prop-details"><code
+            class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+          <div class="docs-prop-description">
+            <div class="docs-section">
+              <div class="bp3-running-text">
+                <p>Whether this input should use small styles.</p>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+ {{/db-drawer/body}}
+</DbDrawer>
+
+<DbDrawer @isOpen={{isOpenButtonDrawer}} 
+ @autoFocus=true @enforceFocus=true
+@hasBackdrop=true @usePortal=true 
+@canOutsideClickClose=true
+@canEscapeKeyClose=true >
+
+{{#db-drawer/body}}
+   <div class="docs-modifiers-table bp3-running-text">
+    <table class="bp3-html-table">
+        <thead>
+            <tr>
+                <th>Props</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td class="docs-prop-name">
+                    <code>active</code>
+                </td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted">false</em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>If set to <code>true</code>, The button will display in an active state.
+                                    This is equivalent to setting <code>className='bp3-active'</code>.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="docs-prop-tags"></div>
+                </td>
+            </tr>
+            <tr>
+                <td class="docs-prop-name"><code>class</code></td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>A space-delimited list of class names to pass along to a child element.</p>
+                            </div>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td class="docs-prop-name"><code>style</code></td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>Inline html style to parent element.</p>
+                            </div>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td class="docs-prop-name"><code>disabled</code></td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>Whether this action is non-interactive.</p>
+                            </div>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td class="docs-prop-name"><code>intent</code></td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>Visual intent color to apply to element. Options are
+                                    <code>primary,success,warning,danger,none.</code></p>
+                            </div>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td class="docs-prop-name"><code>fill</code></td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>Whether this button should expand to fill its container.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="docs-prop-tags"></div>
+                </td>
+            </tr>
+            <tr>
+                <td class="docs-prop-name"><code>icon</code></td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>{{#link-to 'docs.icon.icons'}}IconName{{/link-to}} </strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>Name of a Blueprint UI icon to render before the text.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="docs-prop-tags"><span class="bp3-tag bp3-minimal"><span
+                                class="bp3-text-overflow-ellipsis bp3-fill">
+                                Default icon position is left</span></span>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td class="docs-prop-name"><code>iconSize</code></td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>number</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>Size of icon</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="docs-prop-tags"><span class="bp3-tag bp3-minimal">
+                            <span class="bp3-text-overflow-ellipsis bp3-fill">
+                                Default icon height is 16</span>
+                        </span>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td class="docs-prop-name"><code>large</code></td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>Whether this button should use large styles.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="docs-prop-tags"></div>
+                </td>
+            </tr>
+            <tr>
+                <td class="docs-prop-name"><code>minimal</code></td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>Whether this button should use minimal styles.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="docs-prop-tags"></div>
+                </td>
+            </tr>
+            <tr>
+                <td class="docs-prop-name"><code>rightIcon</code></td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>{{#link-to 'docs.icon.icons'}}IconName{{/link-to}}</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>Name of a Blueprint UI icon to render after the text.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="docs-prop-tags"></div>
+                </td>
+            </tr>
+            <tr>
+                <td class="docs-prop-name"><code>small</code></td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>boolean</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>Whether this button should use small styles.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="docs-prop-tags"></div>
+                </td>
+            </tr>
+            <tr>
+                <td class="docs-prop-name"><code>text</code></td>
+                <td class="docs-prop-details">
+                    <code
+                        class="docs-prop-type"><strong>string</strong><em class="docs-prop-default bp3-text-muted"></em></code>
+                    <div class="docs-prop-description">
+                        <div class="docs-section">
+                            <div class="bp3-running-text">
+                                <p>Action text.</p>
+                            </div>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <br>
+    <div class="docs-prop-tags"><span class="bp3-tag bp3-minimal"><span class="bp3-text-overflow-ellipsis bp3-fill">
+                NOTE: only one color can be used at a time. i.e `primary/success/warning/danger`</span></span>
+    </div>
+    <br>
+    <div class="bp3-callout bp3-intent-danger ">
+        <h4 class="bp3-heading">
+            <Icon @icon='error' @iconSize=16 /> Disabled <code>Button</code> prevents all
+            interaction
+        </h4>
+    </div>
+</div>
+ {{/db-drawer/body}}
+</DbDrawer>

--- a/tests/integration/components/select/component-test.ts
+++ b/tests/integration/components/select/component-test.ts
@@ -188,7 +188,8 @@ module('Integration | Component | select', function (hooks) {
     ];
     this.set('data', data);
     this.set('selected', 'hi2');
-    await render(hbs`<Select  @data={{data}} @selected={{selected}} @placeholder='any text' />`);
+    this.set('InputGroupProps', { placeholder: 'any text' });
+    await render(hbs`<Select  @data={{data}} @selected={{selected}} @InputGroupProps={{InputGroupProps}}/>`);
     var placeHolder: any = document.querySelector('.bp3-input');
     assert.equal(placeHolder.placeholder, 'any text');
   });
@@ -209,7 +210,8 @@ module('Integration | Component | select', function (hooks) {
     ];
     this.set('data', data);
     this.set('selected', 'hi2');
-    await render(hbs`<Select @type='button' @data={{data}} @selected={{selected}} @active=true @placeholder='any text'  />`);
+    this.set('ButtonProps', { active: true });
+    await render(hbs`<Select @type='button' @data={{data}} @selected={{selected}} @ButtonProps={{ButtonProps}} @placeholder='any text'  />`);
     assert.ok(document.querySelector('.bp3-active'));
   });
   test(' minimal=true is rendering ', async function (assert) {
@@ -230,7 +232,8 @@ module('Integration | Component | select', function (hooks) {
     this.set('data', data);
     this.set('selected', 'hi2');
     this.set('buttonProps', { minimal: true });
-    await render(hbs`<Select @type='button' @data={{data}} @selected={{selected}} @buttonProps={{buttonProps}} @placeholder='any text'  />`);
+    this.set('ButtonProps', { minimal: true });
+    await render(hbs`<Select @type='button' @data={{data}} @selected={{selected}} @ButtonProps={{ButtonProps}} @placeholder='any text'  />`);
     assert.ok(document.querySelector('.bp3-minimal'));
   });
 });


### PR DESCRIPTION
Able to render child components properties  with help of combined props object.
example for how to achieve button child props 
`template.hbs`
```
   <Select  @type='button' 
     @ButtonProps={{ButtonProps}} 
   </Select>
```
`component.ts`
```
 ButtonProps: object = {
    icon: 'select',
    placeholder: 'select item',
    rightIcon: 'caret-down',
    active: 'true',
    select: 'icon'
  }
```
The `ButtonProps` object contains required main properties for child component and action functions are handled in main component (listed in docs).   
 