### PR TITLE
BugFix_ Portal false prop Drawer contents attached to its parent container 

### DIFF
--- a/addon/-private/common/classes.ts
+++ b/addon/-private/common/classes.ts
@@ -3,7 +3,7 @@ import { Alignment } from "./alignment";
 import { Elevation } from "./elevation";
 import { Intent } from "./intent";
 
-const NS =  "bp3";
+const NS = "bp3";
 
 // modifiers
 export const ACTIVE = `${NS}-active`;
@@ -169,6 +169,7 @@ export const OVERFLOW_LIST_SPACER = `${OVERFLOW_LIST}-spacer`;
 export const OVERLAY = `${NS}-overlay`;
 export const OVERLAY_BACKDROP = `${OVERLAY}-backdrop`;
 export const OVERLAY_CONTENT = `${OVERLAY}-content`;
+export const OVERLAY_CONTAINER = `${OVERLAY}-container`;
 export const OVERLAY_INLINE = `${OVERLAY}-inline`;
 export const OVERLAY_OPEN = `${OVERLAY}-open`;
 export const OVERLAY_SCROLL_CONTAINER = `${OVERLAY}-scroll-container`;

--- a/addon/components/db-drawer/component.ts
+++ b/addon/components/db-drawer/component.ts
@@ -9,16 +9,16 @@ import * as Classes from '../../-private/common/classes';
 @layout(template)
 export default class DbDrawer extends Component {
   @readOnly('backdropClassName') backdropClass!: string;
-  
+
   @attribute('style') style: any = Ember.String.htmlSafe(this.style);
-  
-  DRAWER:string=Classes.DRAWER +' '+ Classes.OVERLAY_CONTENT;
-  PORTAL:string=Classes.PORTAL;
-  OVERLAY_CONTENT:string=Classes.OVERLAY_CONTENT;
-  OVERLAY:string=Classes.OVERLAY;
-  OVERLAY_OPEN:string=Classes.OVERLAY_OPEN;
-  OVERLAY_BACKDROP:string=Classes.OVERLAY_BACKDROP;
-  OVERLAY_INLINE:string=Classes.OVERLAY_INLINE;
+
+  DRAWER: string = Classes.DRAWER + ' ' + Classes.OVERLAY_CONTENT;
+  PORTAL: string = Classes.PORTAL;
+  OVERLAY_CONTAINER: string = Classes.OVERLAY_CONTAINER;
+  OVERLAY: string = Classes.OVERLAY;
+  OVERLAY_OPEN: string = Classes.OVERLAY_OPEN;
+  OVERLAY_BACKDROP: string = Classes.OVERLAY_BACKDROP;
+  OVERLAY_INLINE: string = Classes.OVERLAY_INLINE;
   drawerId: string = '';
   backDropId: string = '';
   portalClassName!: string;
@@ -34,13 +34,13 @@ export default class DbDrawer extends Component {
   vertical: boolean = false;
   onClose!: (e: any) => void;
   isLeft: boolean = false;
-  
+
   init() {
     super.init();
     this.enforceFocusFun = this.enforceFocusFun.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
   }
-  
+
   didReceiveAttrs() {
     super.init();
     if (this.get('usePortal')) {
@@ -48,14 +48,14 @@ export default class DbDrawer extends Component {
     }
     this.set('isInterval', true);
   }
-  
+
   didInsertElement() {
     super.init();
     this.set('drawerId', 'drawer' + this.elementId);
     this.set('backDropId', 'backDrop' + this.elementId);
 
   }
-  
+
   didRender() {
 
     if (this.drawerId != '' && this.get('isOpen') && this.get('isInterval')) {
@@ -87,7 +87,7 @@ export default class DbDrawer extends Component {
     }
 
   }
-  
+
   @action
   async outerClickToClose(e: any) {
     if (!this.get('canOutsideClickClose'))
@@ -152,7 +152,7 @@ export default class DbDrawer extends Component {
       e.stopImmediatePropagation();
     }
   }
-  
+
   handleKeyDown(e: any) {
     if (this.isDestroyed || this.isDestroying)
       return;

--- a/addon/components/db-drawer/template.hbs
+++ b/addon/components/db-drawer/template.hbs
@@ -3,7 +3,11 @@
     {{#dom-outer-render destinationElementId="destination"}}
       <div class="{{PORTAL}} {{portalClassName}}">
         <div
-          class="{{OVERLAY}} {{OVERLAY_CONTENT}} {{if isOpen OVERLAY_OPEN ""}}"
+          class="{{OVERLAY}}
+
+            {{OVERLAY_CONTAINER}}
+
+            {{if isOpen OVERLAY_OPEN ""}}"
         >
           <div
             id={{backDropId}}
@@ -23,13 +27,13 @@
     {{/dom-outer-render}}
   {{else}}
     <div
-      class="{{OVERLAY_INLINE}}
+      class="{{OVERLAY}}
 
-        {{OVERLAY}}
+        {{OVERLAY_CONTAINER}}
 
-        {{if isOpen OVERLAY_OPEN ""}}
+        {{OVERLAY_INLINE}}
 
-        {{OVERLAY_CONTENT}}"
+        {{if isOpen OVERLAY_OPEN ""}}"
     >
       <div
         id={{backDropId}}

--- a/tests/integration/components/db-drawer/component-test.ts
+++ b/tests/integration/components/db-drawer/component-test.ts
@@ -439,64 +439,62 @@ module('Integration | Component | db-drawer', function (hooks) {
 
   //test on portal =false
 
-  // test('usePortal=false it renders', async function (assert) {
-  //   // Set any properties with this.set('myProperty', 'value');
-  //   // Handle any actions with this.set('myAction', function(val) { ... });
+  test('usePortal=false it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
 
-  //   let that = this;
-  //   this.set('open', false);
-  //   this.set('buttonAction', function () {
-  //     that.set('open', true);
-  //   });
+    let that = this;
+    this.set('open', false);
+    this.set('buttonAction', function () {
+      that.set('open', true);
+    });
 
-  //   await render(hbs` <Button @onClick={{action  buttonAction  }} />
-  //     {{#db-drawer isOpen=this.open usePortal=false}}
-  //     {{#db-drawer/body}}
-  //       template block text
-  //       {{/db-drawer/body}}
-  //     {{/db-drawer}}
-  //     <div id="destination"></div>
-  //   `);
-  //   await click('button');
-  //   var element: any = element;
-  //   assert.equal(element.textContent.trim(), 'template block text');
-  // });
-  // test('render Header component | usePortal=false', async function (assert) {
-  //   let that = this;
-  //   this.set('open', false);
-  //   this.set('buttonAction', function () {
-  //     that.set('open', true);
-  //   });
-  //   await render(hbs` <Button @onClick={{action  buttonAction  }} />
-  //     {{#db-drawer isOpen=this.open usePortal=false}}
-  //     {{#db-drawer/header}}
-  //       template block text
-  //       {{/db-drawer/header}}
-  //     {{/db-drawer}}
-  //     <div id="destination"></div>
-  //   `);
-  //   await click('button');
-  //   var element: any = element;
-  //   assert.equal(element.textContent.trim(), 'template block text');
-  // });
-  // test('render Footer component | usePortal=false', async function (assert) {
-  //   let that = this;
-  //   this.set('open', false);
-  //   this.set('buttonAction', function () {
-  //     that.set('open', true);
-  //   });
-  //   await render(hbs` <Button @onClick={{action  buttonAction  }} />
-  //     {{#db-drawer isOpen=this.open}}
-  //     {{#db-drawer/footer}}
-  //       template block text
-  //       {{/db-drawer/footer}}
-  //     {{/db-drawer}}
-  //     <div id="destination"></div>
-  //   `);
-  //   await click('button');
-  //   var element: any = element;
-  //   assert.equal(element.textContent.trim(), 'template block text');
-  // });
+    await render(hbs` <Button @onClick={{action  buttonAction  }} />
+      {{#db-drawer isOpen=open usePortal=false}}
+      {{#db-drawer/body}}
+        template block text
+        {{/db-drawer/body}}
+      {{/db-drawer}}
+      <div id="destination"></div>
+    `);
+    await click('button');
+    assert.ok(document.querySelector('.bp3-overlay-inline'));
+  });
+  test('render Header component | usePortal=false', async function (assert) {
+    let that = this;
+    this.set('open', false);
+    this.set('buttonAction', function () {
+      that.set('open', true);
+    });
+    await render(hbs` <Button @onClick={{action  buttonAction  }} />
+      {{#db-drawer isOpen=open usePortal=false}}
+      {{#db-drawer/header}}
+        template block text
+        {{/db-drawer/header}}
+      {{/db-drawer}}
+      <div id="destination"></div>
+    `);
+    await click('button');
+    assert.ok(document.querySelector('.bp3-overlay-inline .bp3-drawer-header'));
+  });
+  test('render Footer component | usePortal=false', async function (assert) {
+    let that = this;
+    this.set('open', false);
+    this.set('buttonAction', function () {
+      that.set('open', true);
+    });
+    await render(hbs` <Button @onClick={{action  buttonAction  }} />
+      {{#db-drawer isOpen=open usePortal=false}}
+      {{#db-drawer/footer}}
+        template block text
+        {{/db-drawer/footer}}
+      {{/db-drawer}}
+      <div id="destination"></div>
+    `);
+    await click('button');
+    var element: any = element;
+    assert.ok(document.querySelector('.bp3-overlay-inline .bp3-drawer-footer'));
+  });
   test('Default size for drawer | usePortal=false', async function (assert) {
     let that = this;
     this.set('open', false);


### PR DESCRIPTION
`@portal` prop essentially determines which element is covered by the backdrop. if it is false, then only its parent is covered: otherwise, the entire page is covered at outer dom.
Here attached drawer component to its parent if `parent` prop is false.
  
fixes #49 