### PR TITLE
BugFix_InputGroup should support onChange function

### DIFF
--- a/addon/components/input-group/component.ts
+++ b/addon/components/input-group/component.ts
@@ -50,6 +50,7 @@ export default class InputGroup extends Component {
   onkeyDown!: (value: any, event: any) => void;
   onDoubleClick!: (value: any, event: any) => void;
   onBlur!: (value: any, event: any) => void;
+  onChange!: (value: any, event: any) => void;
   rightIconClick!: (event: any) => void;
   leftIconClick!: (event: any) => void;
 
@@ -84,6 +85,12 @@ export default class InputGroup extends Component {
   keyDown(event: any) {
     if (get(this, 'onkeyDown'))
       get(this, 'onkeyDown')(event.target.value, event);
+  }
+
+  @action
+  onInputChange(event: any) {
+    if (get(this, 'onChange'))
+      get(this, 'onChange')(event.target.value, event);
   }
 
   @action

--- a/addon/components/input-group/template.hbs
+++ b/addon/components/input-group/template.hbs
@@ -22,6 +22,7 @@
   type={{type}}
   class={{INPUT}}
   disabled={{disabled}}
+  onchange={{action "onInputChange"}}
  />
 
 {{#if hasBlock}}

--- a/tests/dummy/app/docs/core/input-group/template.md
+++ b/tests/dummy/app/docs/core/input-group/template.md
@@ -259,6 +259,34 @@ the DOM; the most common ones are detailed below.</p>
         </td>
       </tr>
       <tr>
+  <td class="docs-prop-name">
+    <code>
+      onChange
+    </code>
+  </td>
+  <td class="docs-prop-details">
+    <code class="docs-prop-type">
+      <strong>
+        (HTMLElement, string | number | integer)=> void
+      </strong>
+      <em class="docs-prop-default bp3-text-muted"></em>
+    </code>
+    <div class="docs-prop-description">
+      <div class="docs-section">
+        <div class="bp3-running-text">
+          <p>
+            Change event handler. Use
+            <code>
+              event.target.value
+            </code>
+            for new value.
+          </p>
+        </div>
+      </div>
+    </div>
+  </td>
+</tr>
+      <tr>
         <td class="docs-prop-name"><code>onClick</code></td>
         <td class="docs-prop-details"><code
             class="docs-prop-type"><strong>(data:string, event: MouseEvent&lt;HTMLElement&gt;) =&gt; void</strong><em class="docs-prop-default bp3-text-muted"></em></code>

--- a/tests/integration/components/input-group/component-test.ts
+++ b/tests/integration/components/input-group/component-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, triggerKeyEvent, click, doubleClick, blur } from '@ember/test-helpers';
+import { render, triggerKeyEvent, click, doubleClick } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | input-group', function (hooks) {

--- a/tests/integration/components/input-group/component-test.ts
+++ b/tests/integration/components/input-group/component-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, triggerKeyEvent, click, doubleClick } from '@ember/test-helpers';
+import { render, triggerKeyEvent, click, doubleClick, blur } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | input-group', function (hooks) {
@@ -166,6 +166,19 @@ module('Integration | Component | input-group', function (hooks) {
       <InputGroup @value='hellow' @onkeyDown={{action keyDown}} />
     `);
     await triggerKeyEvent('input', 'keydown', "Enter")
+    assert.equal((this.element as any).querySelector('input').value, this.get('value'));
+  });
+  test(' onChnage event', async function (assert) {
+    var that = this;
+    this.set('onChnage', function (value: string) {
+      that.set('value', value);
+    });
+    await render(hbs`
+      <InputGroup @value='hellow' @onChange={{action onChnage}} />
+    `);
+    await this.set('value', "hellow");
+    await triggerKeyEvent('input', 'keydown', "Enter")
+
     assert.equal((this.element as any).querySelector('input').value, this.get('value'));
   });
 


### PR DESCRIPTION
`onChange` function is only triggered when the control is blurred. Try `onkeyDown` instead.

`onChange function return 2 arguments 
1. HtmlInputElement
2. value of input box

fixes #55 