### PR TITLE
fix(overlay): resolve transition issue with overlay

### DIFF
--- a/packages/core/addon/components/overlay/index.hbs
+++ b/packages/core/addon/components/overlay/index.hbs
@@ -2,6 +2,7 @@
 </span>
 {{#if this.renderInPlace}}
   <div class={{rw this.PORTAL this.getPortalClassName}}>
+    {{! template-lint-disable}}
     <div
       class={{rw
         this.OVERLAY
@@ -11,8 +12,6 @@
       }}
       {{did-insert this.getRefElement}}
       onKeyDown={{action 'handleKeyDown'}}
-      {{!
-			template-lint-disable}}
     >
       {{#if (and this.getLazyProp this.getHasEverOpened)}}
         {{#if this.getIsShowContentAnimation}}
@@ -40,6 +39,7 @@
           </div>
         {{/if}}
       {{else}}
+        {{! template-lint-disable no-invalid-interactive}}
         {{#if this.getIsOpenProp}}
           {{yield}}
         {{/if}}
@@ -61,7 +61,7 @@
         {{did-insert this.getRefElement}}
         onKeyDown={{action 'handleKeyDown'}}
         {{!
-				template-lint-disable}}
+        template-lint-disable}}
       >
         {{#if (and this.getLazyProp this.getHasEverOpened)}}
           {{#if this.getIsShowContentAnimation}}
@@ -70,18 +70,30 @@
                 class={{rw this.OVERLAY_BACKDROP this.getBackdropClassName}}
                 tabIndex={{if this.getCanOutsideClickCloseProp 0 null}}
                 onMouseDown={{action 'handleBackdropMouseDown'}}
-                {{css-transition this.getTransitionName}}
-                {{! template-lint-disable}}
+                {{css-transition
+                  enterClass=(concat this.getTransitionName '-enter')
+                  enterActiveClass=(concat this.getTransitionName '-enter')
+                  enterToClass=(concat this.getTransitionName '-enter-active')
+                  leaveClass=(concat this.getTransitionName '-leave')
+                  leaveActiveClass=(concat this.getTransitionName '-leave')
+                  leaveToClass=(concat this.getTransitionName '-leave-active')
+                }}
               >
               </div>
             {{/if}}
-
             <div
               class={{rw this.OVERLAY_CONTENT}}
               ...attributes
               {{did-update this.didUpdateElement this.getIsOpenProp}}
               {{will-destroy this.willDestroyElementComp}}
-              {{css-transition this.getTransitionName}}
+              {{css-transition
+                enterClass=(concat this.getTransitionName '-enter')
+                enterActiveClass=(concat this.getTransitionName '-enter')
+                enterToClass=(concat this.getTransitionName '-enter-active')
+                leaveClass=(concat this.getTransitionName '-leave')
+                leaveActiveClass=(concat this.getTransitionName '-leave')
+                leaveToClass=(concat this.getTransitionName '-leave-active')
+              }}
             >
               {{#if (has-block)}}
                 {{yield}}


### PR DESCRIPTION
close #370 

* Update  `css-transition` component props accordingly 

<img width="637" alt="image" src="https://github.com/jugaadi/ember-elements/assets/33143395/212faf5d-a034-4d7d-b6e7-9ce8716347d8">

<img width="761" alt="image" src="https://github.com/jugaadi/ember-elements/assets/33143395/566d69a4-27e6-47cb-8bda-d89abe50c617">


